### PR TITLE
add filter options with assetCode to listing transaction

### DIFF
--- a/packages/stellar_client/lib/src/client.dart
+++ b/packages/stellar_client/lib/src/client.dart
@@ -358,7 +358,8 @@ class Client {
     }
   }
 
-  Future<List<Map<String, dynamic>>> getTransactions() async {
+  Future<List<Map<String, dynamic>>> getTransactions(
+      {String? assetCodeFilter}) async {
     Page<OperationResponse> payments = await _sdk.payments
         .forAccount(accountId)
         .order(RequestBuilderOrder.DESC)
@@ -368,16 +369,22 @@ class Client {
     if (payments.records != null && payments.records!.isNotEmpty) {
       for (OperationResponse response in payments.records!) {
         if (response is PaymentOperationResponse) {
-          var details = _handlePaymentOperationResponse(response);
-          transactionDetails.add({'type': 'Payment', 'details': details});
+          String assetCode = response.assetCode ?? 'XLM';
+          if (assetCodeFilter == null || assetCode == assetCodeFilter) {
+            var details = _handlePaymentOperationResponse(response);
+            transactionDetails.add({'type': 'Payment', 'details': details});
+          }
         } else if (response is CreateAccountOperationResponse) {
           var details = _handleCreateAccountOperationResponse(response);
           transactionDetails.add({'type': 'CreateAccount', 'details': details});
         } else if (response is PathPaymentStrictReceiveOperationResponse) {
-          var details =
-              _handlePathPaymentStrictReceiveOperationResponse(response);
-          transactionDetails
-              .add({'type': 'PathPaymentStrictReceive', 'details': details});
+          String assetCode = response.assetCode ?? 'XLM';
+          if (assetCodeFilter == null || assetCode == assetCodeFilter) {
+            var details =
+                _handlePathPaymentStrictReceiveOperationResponse(response);
+            transactionDetails
+                .add({'type': 'PathPaymentStrictReceive', 'details': details});
+          }
         } else {
           print("Unhandled operation type: ${response.runtimeType}");
         }

--- a/packages/stellar_client/lib/src/client.dart
+++ b/packages/stellar_client/lib/src/client.dart
@@ -368,30 +368,22 @@ class Client {
 
     if (payments.records != null && payments.records!.isNotEmpty) {
       for (OperationResponse response in payments.records!) {
-        if (response is CreateAccountOperationResponse &&
-            assetCodeFilter == null) {
+        if (response is PaymentOperationResponse) {
+          String assetCode = response.assetCode ?? 'XLM';
+          if (assetCodeFilter == null || assetCode == assetCodeFilter) {
+            var details = _handlePaymentOperationResponse(response);
+            transactionDetails.add({'type': 'Payment', 'details': details});
+          }
+        } else if (response is CreateAccountOperationResponse) {
           var details = _handleCreateAccountOperationResponse(response);
           transactionDetails.add({'type': 'CreateAccount', 'details': details});
-        } else if (response is PaymentOperationResponse ||
-            response is PathPaymentStrictReceiveOperationResponse) {
-          String assetCode = response is PaymentOperationResponse
-              ? response.assetCode ?? 'XLM'
-              : (response as PathPaymentStrictReceiveOperationResponse)
-                      .assetCode ??
-                  'XLM';
-
+        } else if (response is PathPaymentStrictReceiveOperationResponse) {
+          String assetCode = response.assetCode ?? 'XLM';
           if (assetCodeFilter == null || assetCode == assetCodeFilter) {
-            var details = response is PaymentOperationResponse
-                ? _handlePaymentOperationResponse(response)
-                : _handlePathPaymentStrictReceiveOperationResponse(
-                    response as PathPaymentStrictReceiveOperationResponse);
-
-            transactionDetails.add({
-              'type': response is PaymentOperationResponse
-                  ? 'Payment'
-                  : 'PathPaymentStrictReceive',
-              'details': details
-            });
+            var details =
+                _handlePathPaymentStrictReceiveOperationResponse(response);
+            transactionDetails
+                .add({'type': 'PathPaymentStrictReceive', 'details': details});
           }
         } else {
           print("Unhandled operation type: ${response.runtimeType}");
@@ -400,7 +392,6 @@ class Client {
     } else {
       print("No payment records found.");
     }
-
     return transactionDetails;
   }
 

--- a/packages/stellar_client/lib/src/client.dart
+++ b/packages/stellar_client/lib/src/client.dart
@@ -375,8 +375,11 @@ class Client {
             transactionDetails.add({'type': 'Payment', 'details': details});
           }
         } else if (response is CreateAccountOperationResponse) {
-          var details = _handleCreateAccountOperationResponse(response);
-          transactionDetails.add({'type': 'CreateAccount', 'details': details});
+          if (assetCodeFilter == null) {
+            var details = _handleCreateAccountOperationResponse(response);
+            transactionDetails
+                .add({'type': 'CreateAccount', 'details': details});
+          }
         } else if (response is PathPaymentStrictReceiveOperationResponse) {
           String assetCode = response.assetCode ?? 'XLM';
           if (assetCodeFilter == null || assetCode == assetCodeFilter) {


### PR DESCRIPTION
### Description

- User can filter with asset code when listing its transactions.
### Changes

- Added assetCode option to `getTransactions` function.
### Related Issues
- https://github.com/codescalers/tfgrid-sdk-dart/issues/76

- Listing all transactions
![image](https://github.com/user-attachments/assets/f6215c7b-6f1b-4bf5-b892-1238d30bfcb6)

- Listing with `XLM` filter.
![image](https://github.com/user-attachments/assets/51e6e416-7fc6-4d46-9c29-90f16a5be123)

- Listing with `TFT` filter.
![image](https://github.com/user-attachments/assets/74caae40-c471-4819-87c3-8dfdcda444ad)


### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Code format
- [x] Screenshots/Video attached (needed for UI changes)