### PR TITLE
Add `build.yaml` in graphql and gridproxy clients

### DIFF
--- a/packages/graphql_client/build.yaml
+++ b/packages/graphql_client/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      reflectable:
+        generate_for:
+          - lib/**/*.dart

--- a/packages/graphql_client/build.yaml
+++ b/packages/graphql_client/build.yaml
@@ -1,6 +1,6 @@
 targets:
   $default:
     builders:
-      reflectable:
+      graphql_client:
         generate_for:
           - lib/**/*.dart

--- a/packages/gridproxy_client/build.yaml
+++ b/packages/gridproxy_client/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      reflectable:
+        generate_for:
+          - lib/**/*.dart

--- a/packages/gridproxy_client/build.yaml
+++ b/packages/gridproxy_client/build.yaml
@@ -1,6 +1,7 @@
 targets:
   $default:
     builders:
-      reflectable:
+      gridproxy_client:
         generate_for:
           - lib/**/*.dart
+


### PR DESCRIPTION
### Description

Added `build.yaml` file in graphql and gridproxy clients to be able to run the clients from external projects.
### Changes

- Added Configuration for `reflectable` builder that will enable automatic generation of reflection code.

