### PR TITLE
Add a global setup manager instance

### DIFF
--- a/packages/tfchain_client/pubspec.lock
+++ b/packages/tfchain_client/pubspec.lock
@@ -516,11 +516,9 @@ packages:
   signer:
     dependency: "direct main"
     description:
-      path: "packages/signer"
-      ref: main_fix_urls
-      resolved-ref: d5204d4a5af4f1fbf80334db8039e17f9e323161
-      url: "https://github.com/threefoldtech/tfgrid-sdk-dart.git"
-    source: git
+      path: "../signer"
+      relative: true
+    source: path
     version: "0.1.0"
   source_map_stack_trace:
     dependency: transitive

--- a/packages/tfchain_client/test/balances_test.dart
+++ b/packages/tfchain_client/test/balances_test.dart
@@ -5,18 +5,13 @@ import 'package:tfchain_client/generated/dev/types/frame_system/account_info.dar
 import 'package:tfchain_client/tfchain_client.dart';
 import 'package:bip39/bip39.dart' as bip39;
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group("Balances Tests", () {
-    final setupManager = SetupManager();
     late final String recipientAddress;
     late final Client alice;
-
     setUpAll(() async {
-      setupManager.setInitializationFlags(client: true);
-      await setupManager.setup();
-
       final mnemonic = bip39.generateMnemonic();
       final recipientClient =
           Client(setupManager.url, mnemonic, setupManager.type);

--- a/packages/tfchain_client/test/balances_test.dart
+++ b/packages/tfchain_client/test/balances_test.dart
@@ -6,12 +6,15 @@ import 'package:tfchain_client/tfchain_client.dart';
 import 'package:bip39/bip39.dart' as bip39;
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group("Balances Tests", () {
+    late SetupManager setupManager;
     late final String recipientAddress;
     late final Client alice;
     setUpAll(() async {
+      setupManager = await getSetupManager();
       final mnemonic = bip39.generateMnemonic();
       final recipientClient =
           Client(setupManager.url, mnemonic, setupManager.type);
@@ -25,13 +28,13 @@ void main() {
           address: setupManager.client.address, amount: setupManager.myBalance);
     });
 
-    test('Test Get Balance', () async {
+    test('Get balance', () async {
       AccountInfo? accountInfo = await setupManager.client.balances
           .get(address: setupManager.myAddress);
       expect(accountInfo, isNotNull);
     });
 
-    test('Test Get Balance with Invalid address', () async {
+    test('Get balance with invalid address', () async {
       try {
         AccountInfo? accountInfo =
             await setupManager.client.balances.get(address: "invalidAddress");
@@ -41,7 +44,7 @@ void main() {
       }
     });
 
-    test('Test Transfer TFTs with invalid amount', () async {
+    test('Transfer TFTs with invalid amount', () async {
       try {
         await setupManager.client.balances
             .transfer(address: recipientAddress, amount: BigInt.zero);
@@ -50,7 +53,7 @@ void main() {
       }
     });
 
-    test('Test Transfer TFTs', () async {
+    test('Transfer TFTs', () async {
       try {
         var random = Random();
         var randomNumber = random.nextInt(1000) + 1;
@@ -70,7 +73,7 @@ void main() {
       }
     });
 
-    test('Test get my balance', () async {
+    test('Get my balance', () async {
       AccountInfo? info = await setupManager.client.balances.getMyBalance();
       expect(info, isNotNull);
     });

--- a/packages/tfchain_client/test/client_test.dart
+++ b/packages/tfchain_client/test/client_test.dart
@@ -13,9 +13,15 @@ import 'package:tfchain_client/src/tft_price.dart';
 import 'package:tfchain_client/src/twins.dart';
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group('Client Tests', () {
+    late SetupManager setupManager;
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+
     test('Initialization', () {
       expect(setupManager.queryClient.url, equals(setupManager.url));
       expect(setupManager.queryClient.contracts, isA<QueryContracts>());

--- a/packages/tfchain_client/test/client_test.dart
+++ b/packages/tfchain_client/test/client_test.dart
@@ -12,16 +12,10 @@ import 'package:tfchain_client/src/tft_bridge.dart';
 import 'package:tfchain_client/src/tft_price.dart';
 import 'package:tfchain_client/src/twins.dart';
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group('Client Tests', () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(queryClient: true, client: true);
-      await setupManager.setup();
-    });
-
     test('Initialization', () {
       expect(setupManager.queryClient.url, equals(setupManager.url));
       expect(setupManager.queryClient.contracts, isA<QueryContracts>());

--- a/packages/tfchain_client/test/contracts_test.dart
+++ b/packages/tfchain_client/test/contracts_test.dart
@@ -7,9 +7,13 @@ import 'setup_manager.dart';
 
 void main() {
   group("Contracts Tests", () {
+    late SetupManager setupManager;
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
     List<BigInt> contractIds = [];
 
-    test('Test Get Contract with wrong id', () async {
+    test('Get Contract with wrong id', () async {
       try {
         Contract? contract = await setupManager.client.contracts
             .get(contractId: BigInt.from(-100));
@@ -19,7 +23,7 @@ void main() {
       }
     });
 
-    test('Test Get Contract Id by active rent for invalid node id', () async {
+    test('Get Contract Id by active rent for invalid node id', () async {
       try {
         BigInt? contractId = await setupManager.client.contracts
             .getContractIdByActiveRentForNode(nodeId: -21);
@@ -29,7 +33,7 @@ void main() {
       }
     });
 
-    test('Test Get Active Contracts by wrong node Id', () async {
+    test('Get active contracts by wrong node id', () async {
       try {
         List<int> contracts =
             await setupManager.client.contracts.getActiveContracts(nodeId: -21);
@@ -39,7 +43,7 @@ void main() {
       }
     });
 
-    test('Test Get Contract Lock by deleted Contract Id', () async {
+    test('Get contract lock by deleted contract id', () async {
       try {
         final name = generateRandomString(7);
         BigInt? contractId =
@@ -54,7 +58,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 50)));
 
-    test('Test Update Node Contract with wrong data', () async {
+    test('Update node contract with wrong data', () async {
       try {
         await setupManager.client.contracts.updateNode(
             contractId: BigInt.from(-200),
@@ -65,7 +69,7 @@ void main() {
       }
     });
 
-    test('Test Create Name Contract', () async {
+    test('Create name contract', () async {
       final name = generateRandomString(6);
       final contractId =
           await setupManager.client.contracts.createName(name: name);

--- a/packages/tfchain_client/test/contracts_test.dart
+++ b/packages/tfchain_client/test/contracts_test.dart
@@ -2,15 +2,11 @@ import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_smart_contract/types/contract.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_smart_contract/types/contract_lock.dart';
 
+import 'globals.dart';
 import 'setup_manager.dart';
 
 void main() {
   group("Contracts Tests", () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(client: true);
-      await setupManager.setup();
-    });
     List<BigInt> contractIds = [];
 
     test('Test Get Contract with wrong id', () async {

--- a/packages/tfchain_client/test/farms_test.dart
+++ b/packages/tfchain_client/test/farms_test.dart
@@ -1,16 +1,12 @@
 import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/tfchain_support/types/farm.dart';
 
+import 'globals.dart';
 import 'setup_manager.dart';
 
 void main() {
   group("Farms Test", () {
     Map<int, String> farmsIps = {};
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(client: true);
-      await setupManager.setup();
-    });
     test('Test Get Farm by Id', () async {
       int? farmId = await setupManager.client.farms
           .create(name: generateRandomString(6), publicIps: []);

--- a/packages/tfchain_client/test/farms_test.dart
+++ b/packages/tfchain_client/test/farms_test.dart
@@ -7,15 +7,20 @@ import 'setup_manager.dart';
 void main() {
   group("Farms Test", () {
     Map<int, String> farmsIps = {};
-    test('Test Get Farm by Id', () async {
+    late SetupManager setupManager;
+
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+    test('Get Farm by Id', () async {
       int? farmId = await setupManager.client.farms
           .create(name: generateRandomString(6), publicIps: []);
 
       Farm? farm = await setupManager.client.farms.get(id: farmId!);
-      expect(farm!.id, farmId);
+      expect(farm?.id, farmId);
     });
 
-    test('Test Get Farm by invalid Id', () async {
+    test('Get Farm by invalid Id', () async {
       try {
         Farm? farm = await setupManager.client.farms.get(id: -2);
       } catch (e) {
@@ -23,13 +28,13 @@ void main() {
       }
     });
 
-    test('Test create farm', () async {
+    test('Create farm', () async {
       final farmId = await setupManager.client.farms
           .create(name: generateRandomString(6), publicIps: []);
       expect(farmId, isNotNull);
     });
 
-    test('Test get farmId by name', () async {
+    test('Get farmId by name', () async {
       final name = generateRandomString(6);
       int? farmId =
           await setupManager.client.farms.create(name: name, publicIps: []);
@@ -37,7 +42,7 @@ void main() {
       expect(res, farmId!);
     });
 
-    test('Test create farm with existing name', () async {
+    test('Create farm with existing name', () async {
       try {
         final name = generateRandomString(6);
         await setupManager.client.farms.create(name: name, publicIps: []);
@@ -48,7 +53,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 50)));
 
-    test('Test adding farm ip with equal ip and gateway', () async {
+    test('Add farm IP with equal IP and gateway', () async {
       try {
         final randomIp = generateRandomCIDRIPv4();
         final gatewayIp = randomIp.split('/')[0];
@@ -61,7 +66,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 50)));
 
-    test('Test adding valid IPs to farm,', () async {
+    test('Add valid IPs to farm,', () async {
       try {
         final randomIp = generateRandomCIDRIPv4();
         final ip = randomIp.split('/')[0];
@@ -77,7 +82,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 50)));
 
-    test('Test adding existing ips to farm', () async {
+    test('Add existing IPs to farm', () async {
       try {
         int? farmId1 = await setupManager.client.farms
             .create(name: generateRandomString(5), publicIps: []);
@@ -101,7 +106,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 80)));
 
-    test('Test removing farm IP', () async {
+    test('removing farm IP', () async {
       try {
         final randomIp = generateRandomCIDRIPv4();
         final ip = randomIp.split('/')[0];
@@ -120,7 +125,7 @@ void main() {
       }
     }, timeout: Timeout(Duration(seconds: 60)));
 
-    test('Test adding Stellar Address', () async {
+    test('Add Stellar Address', () async {
       try {
         final farmId = await setupManager.client.farms
             .create(name: generateRandomString(6), publicIps: []);

--- a/packages/tfchain_client/test/globals.dart
+++ b/packages/tfchain_client/test/globals.dart
@@ -1,0 +1,17 @@
+library globals;
+
+import 'package:test/scaffolding.dart';
+
+import 'setup_manager.dart';
+
+final SetupManager setupManager = getSetupManager();
+
+getSetupManager() {
+  final _setupManager = new SetupManager();
+  setUpAll(() async {
+    _setupManager.setInitializationFlags(queryClient: true, client: true);
+    await _setupManager.setup();
+  });
+
+  return _setupManager;
+}

--- a/packages/tfchain_client/test/globals.dart
+++ b/packages/tfchain_client/test/globals.dart
@@ -1,17 +1,11 @@
 library globals;
 
-import 'package:test/scaffolding.dart';
-
 import 'setup_manager.dart';
 
-final SetupManager setupManager = getSetupManager();
-
-getSetupManager() {
+Future<SetupManager> getSetupManager() async {
   final _setupManager = new SetupManager();
-  setUpAll(() async {
-    _setupManager.setInitializationFlags(queryClient: true, client: true);
-    await _setupManager.setup();
-  });
+  _setupManager.setInitializationFlags(queryClient: true, client: true);
+  await _setupManager.setup();
 
   return _setupManager;
 }

--- a/packages/tfchain_client/test/pricing_policies_test.dart
+++ b/packages/tfchain_client/test/pricing_policies_test.dart
@@ -2,15 +2,20 @@ import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_tfgrid/types/pricing_policy.dart';
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group("Query Pricing Policies", () {
-    test('Test Get Pricing Policy', () async {
+    late SetupManager setupManager;
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+    test('Get Pricing Policy', () async {
       PricingPolicy? res = await setupManager.queryClient.policies.get(id: 1);
       expect(res, isNotNull);
     });
 
-    test('Test Get Pricing Policy with wrong Id', () async {
+    test('Get Pricing Policy with wrong Id', () async {
       try {
         PricingPolicy? res =
             await setupManager.queryClient.policies.get(id: -10);

--- a/packages/tfchain_client/test/pricing_policies_test.dart
+++ b/packages/tfchain_client/test/pricing_policies_test.dart
@@ -1,15 +1,10 @@
 import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_tfgrid/types/pricing_policy.dart';
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group("Query Pricing Policies", () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(queryClient: true);
-      await setupManager.setup();
-    });
     test('Test Get Pricing Policy', () async {
       PricingPolicy? res = await setupManager.queryClient.policies.get(id: 1);
       expect(res, isNotNull);

--- a/packages/tfchain_client/test/tft_bridge_test.dart
+++ b/packages/tfchain_client/test/tft_bridge_test.dart
@@ -3,20 +3,25 @@ import 'dart:math';
 import 'package:test/test.dart';
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group("Bridge Tests", () {
-    test('Test Get Withdraw fee', () async {
+    late SetupManager setupManager;
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+    test('Get Withdraw fee', () async {
       BigInt? fee = await setupManager.client.bridge.getWithdrawFee();
       expect(fee, isNotNull);
     });
 
-    test('Test Get Deposit fee', () async {
+    test('Get Deposit fee', () async {
       BigInt? fee = await setupManager.client.bridge.getDepositFee();
       expect(fee, isNotNull);
     });
 
-    test('Test swap to stellar zero TFTs', () async {
+    test('Swap to stellar zero TFTs', () async {
       try {
         await setupManager.client.bridge.swapToStellar(
             target: "GDHJP6TF3UXYXTNEZ2P36J5FH7W4BJJQ4AYYAXC66I2Q2AH5B6O6BCFG",
@@ -26,7 +31,7 @@ void main() {
       }
     });
 
-    test('Test swap to stellar', () async {
+    test('Swap to stellar', () async {
       try {
         var random = Random();
         var randomNumber = random.nextInt(100) + 1;

--- a/packages/tfchain_client/test/tft_bridge_test.dart
+++ b/packages/tfchain_client/test/tft_bridge_test.dart
@@ -2,15 +2,10 @@ import 'dart:math';
 
 import 'package:test/test.dart';
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group("Bridge Tests", () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(client: true);
-      await setupManager.setup();
-    });
     test('Test Get Withdraw fee', () async {
       BigInt? fee = await setupManager.client.bridge.getWithdrawFee();
       expect(fee, isNotNull);

--- a/packages/tfchain_client/test/tft_price_test.dart
+++ b/packages/tfchain_client/test/tft_price_test.dart
@@ -1,14 +1,9 @@
 import 'package:test/test.dart';
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group("Price Tests", () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(queryClient: true);
-      await setupManager.setup();
-    });
     test('Test Get TFT price', () async {
       final price = await setupManager.queryClient.price.get();
       expect(price, isNotNull);

--- a/packages/tfchain_client/test/tft_price_test.dart
+++ b/packages/tfchain_client/test/tft_price_test.dart
@@ -1,10 +1,15 @@
 import 'package:test/test.dart';
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group("Price Tests", () {
-    test('Test Get TFT price', () async {
+    late SetupManager setupManager;
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+    test('Get TFT price', () async {
       final price = await setupManager.queryClient.price.get();
       expect(price, isNotNull);
     });

--- a/packages/tfchain_client/test/twins_test.dart
+++ b/packages/tfchain_client/test/twins_test.dart
@@ -2,28 +2,35 @@ import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_tfgrid/types/twin.dart';
 
 import 'globals.dart';
+import 'setup_manager.dart';
 
 void main() {
   group("Twins Test", () {
-    test('Test Get Twin with id', () async {
+    late SetupManager setupManager;
+
+    setUpAll(() async {
+      setupManager = await getSetupManager();
+    });
+
+    test('Get Twin with id', () async {
       final twin =
           await setupManager.client.twins.get(id: setupManager.twinId!);
       expect(twin!.id, setupManager.twinId);
     });
 
-    test('Test Get Twin with zero id', () async {
+    test('Get Twin with zero id', () async {
       final twin = await setupManager.client.twins.get(id: 0);
       expect(twin, null);
     });
 
-    test('Test Get Twin Id with account Id', () async {
+    test('Get Twin Id with account Id', () async {
       String address = setupManager.myAddress;
       final twin = await setupManager.client.twins
           .getTwinIdByAccountId(address: address);
       expect(twin, setupManager.twinId);
     });
 
-    test('Test Create Twin for existing account', () async {
+    test('Create Twin for existing account', () async {
       try {
         int? twin = await setupManager.client.twins.create(relay: "", pk: []);
       } catch (error) {
@@ -33,7 +40,7 @@ void main() {
         );
       }
     });
-    test('Test Update Twin', () async {
+    test('Update Twin', () async {
       try {
         await setupManager.client.twins
             .update(relay: "relay.qa.grid.tf".codeUnits, pk: []);

--- a/packages/tfchain_client/test/twins_test.dart
+++ b/packages/tfchain_client/test/twins_test.dart
@@ -1,16 +1,10 @@
 import 'package:test/test.dart';
 import 'package:tfchain_client/generated/dev/types/pallet_tfgrid/types/twin.dart';
 
-import 'setup_manager.dart';
+import 'globals.dart';
 
 void main() {
   group("Twins Test", () {
-    final setupManager = SetupManager();
-    setUpAll(() async {
-      setupManager.setInitializationFlags(client: true);
-      await setupManager.setup();
-    });
-
     test('Test Get Twin with id', () async {
       final twin =
           await setupManager.client.twins.get(id: setupManager.twinId!);


### PR DESCRIPTION
### Changes

- Added a setup manager in a global file and called it before all tests
- Fixed tests typos

### Tested Scenarios
- Ran all tests

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-dart/issues/63

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Code format
- [ ] Screenshots/Video attached (needed for UI changes)