### PR TITLE
Export helpers.dart to be seen

### DIFF
--- a/packages/stellar_client/lib/src/helpers.dart
+++ b/packages/stellar_client/lib/src/helpers.dart
@@ -1,6 +1,4 @@
-import 'package:stellar_client/models/balance.dart';
-import 'package:stellar_client/stellar_client.dart';
-import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
+part of '../stellar_client.dart';
 
 Future<List<BalanceInfo>> getBalanceByAccountID(
     {required NetworkType network, required String accountId}) async {

--- a/packages/stellar_client/lib/stellar_client.dart
+++ b/packages/stellar_client/lib/stellar_client.dart
@@ -8,10 +8,10 @@ import 'package:stellar_client/models/currency.dart' as currency;
 import 'package:stellar_client/models/transaction_data.dart';
 import 'package:stellar_client/models/vesting_account.dart';
 import 'package:stellar_client/models/transaction.dart';
-import 'package:stellar_client/src/helpers.dart';
 import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
 import 'package:http/http.dart' as http;
 import 'package:convert/convert.dart';
 
 part 'src/client.dart';
 part 'src/network_types.dart';
+part 'src/helpers.dart';


### PR DESCRIPTION
### Description

- Export `helpers.dart` to be seen when using the package.
### Changes

- make `helpers.dart` part of `stellar_client`.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/767
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Code format
- [ ] Screenshots/Video attached (needed for UI changes)